### PR TITLE
Ticket #2 - Only employees can fire other employees is complete and r…

### DIFF
--- a/src/components/EmployeeRoutes.js
+++ b/src/components/EmployeeRoutes.js
@@ -1,6 +1,5 @@
 import React from "react"
 import { Route } from "react-router-dom"
-
 import Employee from "./employees/Employee"
 import EmployeeList from "./employees/EmployeeList"
 import EmployeeForm from "./employees/EmployeeForm"

--- a/src/components/animals/Animal.js
+++ b/src/components/animals/Animal.js
@@ -83,7 +83,7 @@ export const Animal = ({ animal, syncAnimals,
                                     else {
                                         history.push(`/animals/${currentAnimal.id}`)
                                     }
-                                }}> {currentAnimal.name} </button>
+                                }}> {currentAnimal.name}</button>
                         </h5>
                         <span className="card-text small">{currentAnimal.breed}</span>
                     </div>
@@ -96,17 +96,23 @@ export const Animal = ({ animal, syncAnimals,
                         <section>
                             <h6>Caretaker(s)</h6>
                             <span className="small">
-                            <div >{
-                            currentAnimal?.animalCaretakers?.map(animalCaretaker => <option key={`animalCaretaker--${animalCaretaker.id}`} value={animalCaretaker.id}>{animalCaretaker.user.name}</option>)
-                        } </div>
+                                <div >
+                                    {
+                                        currentAnimal?.animalCaretakers?.map(animalCaretaker => <option key={`animalCaretaker--${animalCaretaker.id}`} value={animalCaretaker.id}>{animalCaretaker.user.name}</option>)
+                                    }
+                                </div>
                             </span>
 
 
                             <h6>Owners</h6>
                             <span className="small">
-                               <div >                             <div >{
-                            currentAnimal?.animalOwners?.map(animalOwner => <option key={`animalOwner--${animalOwner.id}`} value={animalOwner.id}>{animalOwner.user.name}</option>)} </div>
-</div>
+                                <div >
+                                    <div >
+                                        {
+                                            currentAnimal?.animalOwners?.map(animalOwner => <option key={`animalOwner--${animalOwner.id}`} value={animalOwner.id}>{animalOwner.user.name}</option>)
+                                        }
+                                    </div>
+                                </div>
                             </span>
 
                             {

--- a/src/components/employees/Employee.js
+++ b/src/components/employees/Employee.js
@@ -1,21 +1,27 @@
 import React, { useState, useEffect } from "react"
 import { Link, useParams } from "react-router-dom"
-import EmployeeRepository from "../../repositories/EmployeeRepository";
-import useSimpleAuth from "../../hooks/ui/useSimpleAuth";
+import EmployeeRepository from "../../repositories/EmployeeRepository"
+import useSimpleAuth from "../../hooks/ui/useSimpleAuth"
 import useResourceResolver from "../../hooks/resource/useResourceResolver";
 import "./Employee.css"
 import person from "./person.png"
 
 
-export default ({ employee }) => {
+export default ({ employee, syncEmployees }) => {
+    const [isEmployee, setAuth] = useState(false)
     const [animalCount, setCount] = useState(0)
     const [location, markLocation] = useState({ name: "" })
     const [classes, defineClasses] = useState("card employee")
     const { employeeId } = useParams()
     const { getCurrentUser } = useSimpleAuth()
     const { resolveResource, resource } = useResourceResolver()
+    
+    useEffect(() => {
+        setAuth(getCurrentUser().employee)
+        resolveResource(employee, employeeId, EmployeeRepository.get)
+    }, [])
 
-    useEffect(
+   useEffect(
         () => {
             if (employeeId) {
                 defineClasses("card employee--single")
@@ -31,7 +37,7 @@ export default ({ employee }) => {
         }
     }, [resource])
 
-    return (
+     return (
         <article className={classes}>
             <section className="card-body">
                 <img alt="Kennel employee icon" src={person} className="icon--person" />
@@ -46,7 +52,6 @@ export default ({ employee }) => {
                                 }}>
                                 {resource.name}
                             </Link>
-
                     }
                 </h5>
                 {
@@ -61,13 +66,20 @@ export default ({ employee }) => {
                         </>
                         : ""
                 }
+                
 
                 {
-                    <button className="btn--fireEmployee" onClick={() => {}}>Fire</button>
+                    isEmployee
+                        ?
+                        <button className="btn--fireEmployee" onClick={() => 
+                            EmployeeRepository
+                                .delete(employee.id)
+                                .then(() => {
+                                    syncEmployees()
+                                })}>Fire</button>
+                    : ""
                 }
-
             </section>
-
         </article>
     )
 }

--- a/src/components/employees/EmployeeList.js
+++ b/src/components/employees/EmployeeList.js
@@ -23,8 +23,10 @@ export default () => {
         <>
             <div className="employees">
                 {
-                    employees.map(a => <Employee key={a.id} employee={a} />)
+                    employees.map(a => <Employee key={a.id} employee={a} 
+                        syncEmployees={syncEmployees}/>)
                 }
+
             </div>
         </>
     )


### PR DESCRIPTION
WHICH ISSUE DOES THIS ADDRESS? Addresses issue #2 – Only employees can fire other employees

Changes Made:

1.	Added syncEmployees param at ln 26 in EmployeeList.js to export state to Employee
2.	“Fire” button at ln 72 with tertiary to determine if use is an employee. If false, user will not see button.  If true, user will see button and onClick employee is deleted by employee.id from employees table, syncEmployees function is invoked from EmployeeList to rerender DOM.

No added files

Recommendations for Testing

Fetch file “KLL-ticket2_onlyEmployeesCanFireEmployees” and check it out.  Log in as employee and non-employee users and confirm FIRE button is only visible to employees, and when clicked by employee user, selected employee is deleted and DOM is rerendered.