### PR TITLE
Kll ticket12 assign owner to animal

### DIFF
--- a/data/database.json.fixture
+++ b/data/database.json.fixture
@@ -225,7 +225,7 @@
     {
       "id": 17,
       "name": "Dani Adkins",
-      "email": "dani.adkins.com",
+      "email": "dani@adkins.com",
       "employee": false
     },
     {

--- a/src/components/animals/Animal.js
+++ b/src/components/animals/Animal.js
@@ -131,7 +131,7 @@ export const Animal = ({ animal, syncAnimals,
                             </span>
 
                             {
-                                myOwners.length < 2
+                                myOwners.length < 2 && isEmployee
                                     ? <select
                                         name="owner"
                                         className="form-control small"

--- a/src/components/animals/Animal.js
+++ b/src/components/animals/Animal.js
@@ -21,7 +21,7 @@ export const Animal = ({ animal, syncAnimals,
     const { animalId } = useParams()
     const { resolveResource, resource: currentAnimal } = useResourceResolver()
     const [ animalCaretakers, syncAnimalCaretakers ] = useState({})
-
+    
     useEffect(
         () => {
             fetch("http://localhost:8088/animalCaretakers")
@@ -35,6 +35,10 @@ export const Animal = ({ animal, syncAnimals,
         setAuth(getCurrentUser().employee)
         resolveResource(animal, animalId, AnimalRepository.get)
     }, [])
+
+    useEffect(() => {
+        resolveResource(animal, animalId, AnimalRepository.get)
+    }, [animal])
 
     useEffect(() => {
         if (owners) {
@@ -63,6 +67,12 @@ export const Animal = ({ animal, syncAnimals,
                 })
         }
     }, [animalId])
+
+    const assignNewOwner = (chgEvt) => {
+            AnimalOwnerRepository
+                .assignOwner(currentAnimal.id, parseInt(chgEvt.target.value))
+                .then(() => syncAnimals() )
+    }
 
     return (
         <>
@@ -112,9 +122,9 @@ export const Animal = ({ animal, syncAnimals,
                             <h6>Owners</h6>
                             <span className="small">
                                 {
-                                    currentAnimal?.animalOwners?.map(animalOwner => {
+                                    myOwners?.map(animalOwner => {
                                         return <div key={`animalOwner--${animalOwner.id}`}>
-                                        {animalOwner.user.name}
+                                            {animalOwner.user.name}
                                         </div>
                                     })
                                 }
@@ -122,15 +132,17 @@ export const Animal = ({ animal, syncAnimals,
 
                             {
                                 myOwners.length < 2
-                                    ? <select defaultValue=""
+                                    ? <select
                                         name="owner"
                                         className="form-control small"
-                                        onChange={() => {}} >
-                                        <option value="">
-                                            Select {myOwners.length < 1 ? "an" : "another"} owner
-                                        </option>
+                                        onChange={
+                                            assignNewOwner
+                                        } >
+                                            <option value="0">
+                                                Select {myOwners.length < 1 ? "an" : "another"} owner
+                                            </option>
                                         {
-                                            allOwners.map(o => <option key={o.id} value={o.id}>{o.name}</option>)
+                                            allOwners.map(owner => <option key={owner.id} value={owner.id}>{owner.name}</option>)
                                         }
                                     </select>
                                     : null

--- a/src/components/animals/Animal.js
+++ b/src/components/animals/Animal.js
@@ -14,6 +14,7 @@ export const Animal = ({ animal, syncAnimals,
     const [detailsOpen, setDetailsOpen] = useState(false)
     const [isEmployee, setAuth] = useState(false)
     const [myOwners, setPeople] = useState([])
+    debugger
     const [allOwners, registerOwners] = useState([])
     const [classes, defineClasses] = useState("card animal")
     const { getCurrentUser } = useSimpleAuth()
@@ -41,7 +42,7 @@ export const Animal = ({ animal, syncAnimals,
             registerOwners(owners)
         }
     }, [owners])
-
+    
     const getPeople = () => {
         return AnimalOwnerRepository
             .getOwnersByAnimal(currentAnimal.id)
@@ -122,7 +123,7 @@ export const Animal = ({ animal, syncAnimals,
                                         className="form-control small"
                                         onChange={() => {}} >
                                         <option value="">
-                                            Select {myOwners.length === 1 ? "another" : "an"} owner
+                                            Select {myOwners.length < 1 ? "an" : "another"} owner
                                         </option>
                                         {
                                             allOwners.map(o => <option key={o.id} value={o.id}>{o.name}</option>)

--- a/src/components/animals/Animal.js
+++ b/src/components/animals/Animal.js
@@ -14,7 +14,6 @@ export const Animal = ({ animal, syncAnimals,
     const [detailsOpen, setDetailsOpen] = useState(false)
     const [isEmployee, setAuth] = useState(false)
     const [myOwners, setPeople] = useState([])
-    debugger
     const [allOwners, registerOwners] = useState([])
     const [classes, defineClasses] = useState("card animal")
     const { getCurrentUser } = useSimpleAuth()
@@ -121,7 +120,10 @@ export const Animal = ({ animal, syncAnimals,
                                     ? <select defaultValue=""
                                         name="owner"
                                         className="form-control small"
-                                        onChange={() => {}} >
+                                        onChange={
+                                            (changeEvent) => {
+                                                
+                                            }} >
                                         <option value="">
                                             Select {myOwners.length < 1 ? "an" : "another"} owner
                                         </option>

--- a/src/components/animals/Animal.js
+++ b/src/components/animals/Animal.js
@@ -10,7 +10,7 @@ import { prependOnceListener } from "process"
 
 // export to animalList.js
 export const Animal = ({ animal, syncAnimals,
-    showTreatmentHistory, owners }) => {
+    showTreatmentHistory, owners, assignedOwners, setter }) => {
     const [detailsOpen, setDetailsOpen] = useState(false)
     const [isEmployee, setAuth] = useState(false)
     const [myOwners, setPeople] = useState([])
@@ -69,6 +69,7 @@ export const Animal = ({ animal, syncAnimals,
             <li className={classes}>
                 <div className="card-body">
                     <div className="animal__header">
+                        {/*Show animal name with link to medical treatment history (if any)*/}
                         <h5 className="card-title">
                             <button className="link--card btn btn-link"
                                 style={{
@@ -76,6 +77,7 @@ export const Animal = ({ animal, syncAnimals,
                                     "textDecoration": "underline",
                                     "color": "rgb(94, 78, 196)"
                                 }}
+                                /* if user is an employee, allow click to reveal medical history */
                                 onClick={() => {
                                     if (isEmployee) {
                                         showTreatmentHistory(currentAnimal)
@@ -85,21 +87,24 @@ export const Animal = ({ animal, syncAnimals,
                                     }
                                 }}> {currentAnimal.name}</button>
                         </h5>
+                        {/* Show Breed */}
                         <span className="card-text small">{currentAnimal.breed}</span>
 
                     </div>
 
                     <details open={detailsOpen}>
+                        {/* Show randomly generated "stoplight" meter */}
                         <summary className="smaller">
                             <meter min="0" max="100" value={Math.random() * 100} low="25" high="75" optimum="100"></meter>
                         </summary>
 
                         <section>
+                            {/*Display "Caretaker" header and name.*/}
                             <h6>Caretaker(s)</h6>
                             <span className="small">
                                 <div >
                                     {
-                                        currentAnimal?.animalCaretakers?.map(animalCaretaker => <option key={`animalCaretaker--${animalCaretaker.id}`} value={animalCaretaker.id}>{animalCaretaker.user.name}</option>)
+                                        currentAnimal?.animalCaretakers?.map(animalCaretaker => <div key={`animalCaretaker--${animalCaretaker.id}`} value={animalCaretaker.id}>{animalCaretaker.user.name}</div>)
                                     }
                                 </div>
                             </span>
@@ -121,15 +126,22 @@ export const Animal = ({ animal, syncAnimals,
                                         name="owner"
                                         className="form-control small"
                                         onChange={
-                                            (changeEvent) => {
-                                                
+                                            (evt) => {
+                                                 const copy = { ...assignedOwners }
+                                                 console.log(copy)
+                                                 copy.myOwner = myOwners.find(myOwner => myOwner.id === parseInt(evt.target.value)) || {}
+                                                 console.log(`This is ${evt.target.value}`)                                           
                                             }} >
-                                        <option value="">
-                                            Select {myOwners.length < 1 ? "an" : "another"} owner
-                                        </option>
-                                        {
-                                            allOwners.map(o => <option key={o.id} value={o.id}>{o.name}</option>)
-                                        }
+                                            <option value="0">
+                                                Select {myOwners.length < 1 ? "an" : "another"} owner
+                                            </option>
+                                            {
+                                                allOwners.map(owner =>  {
+                                                    return <option
+                                                        key={owner.id}
+                                                        value={owner.id}>{owner.name}</option>
+                                                })
+                                            }
                                     </select>
                                     : null
                             }

--- a/src/components/animals/Animal.js
+++ b/src/components/animals/Animal.js
@@ -10,7 +10,7 @@ import { prependOnceListener } from "process"
 
 // export to animalList.js
 export const Animal = ({ animal, syncAnimals,
-    showTreatmentHistory, owners, assignedOwners, setter }) => {
+    showTreatmentHistory, owners }) => {
     const [detailsOpen, setDetailsOpen] = useState(false)
     const [isEmployee, setAuth] = useState(false)
     const [myOwners, setPeople] = useState([])
@@ -69,7 +69,6 @@ export const Animal = ({ animal, syncAnimals,
             <li className={classes}>
                 <div className="card-body">
                     <div className="animal__header">
-                        {/*Show animal name with link to medical treatment history (if any)*/}
                         <h5 className="card-title">
                             <button className="link--card btn btn-link"
                                 style={{
@@ -77,7 +76,6 @@ export const Animal = ({ animal, syncAnimals,
                                     "textDecoration": "underline",
                                     "color": "rgb(94, 78, 196)"
                                 }}
-                                /* if user is an employee, allow click to reveal medical history */
                                 onClick={() => {
                                     if (isEmployee) {
                                         showTreatmentHistory(currentAnimal)
@@ -87,65 +85,56 @@ export const Animal = ({ animal, syncAnimals,
                                     }
                                 }}> {currentAnimal.name}</button>
                         </h5>
-                        {/* Show Breed */}
                         <span className="card-text small">{currentAnimal.breed}</span>
 
                     </div>
 
                     <details open={detailsOpen}>
-                        {/* Show randomly generated "stoplight" meter */}
                         <summary className="smaller">
                             <meter min="0" max="100" value={Math.random() * 100} low="25" high="75" optimum="100"></meter>
                         </summary>
 
                         <section>
-                            {/*Display "Caretaker" header and name.*/}
                             <h6>Caretaker(s)</h6>
                             <span className="small">
-                                <div >
-                                    {
-                                        currentAnimal?.animalCaretakers?.map(animalCaretaker => <div key={`animalCaretaker--${animalCaretaker.id}`} value={animalCaretaker.id}>{animalCaretaker.user.name}</div>)
-                                    }
-                                </div>
-                            </span>
 
+                            {
+                                currentAnimal?.animalCaretakers?.map(animalCaretaker => {
+                                    return <div key={`animalCaretaker--${animalCaretaker.id}`}>
+                                        {animalCaretaker.user.name}
+                                    </div>
+                                })
+                                
+                            }
+
+                            </span>
 
                             <h6>Owners</h6>
                             <span className="small">
-
-                               <div >                             {
-                            currentAnimal?.animalOwners?.map(animalOwner => <option key={`animalOwner--${animalOwner.id}`} value={animalOwner.id}>{animalOwner.user.name}</option>)} </div>
-                            
-
-                  
+                                {
+                                    currentAnimal?.animalOwners?.map(animalOwner => {
+                                        return <div key={`animalOwner--${animalOwner.id}`}>
+                                        {animalOwner.user.name}
+                                        </div>
+                                    })
+                                }
                             </span>
 
                             {
-                                myOwners.length < 2  //This code controls the drop down, only displays if animal has less than 2 owners otherwise it won't display
+                                myOwners.length < 2
                                     ? <select defaultValue=""
                                         name="owner"
                                         className="form-control small"
-                                        onChange={
-                                            (evt) => {
-                                                 const copy = { ...assignedOwners }
-                                                 console.log(copy)
-                                                 copy.myOwner = myOwners.find(myOwner => myOwner.id === parseInt(evt.target.value)) || {}
-                                                 console.log(`This is ${evt.target.value}`)                                           
-                                            }} >
-                                            <option value="0">
-                                                Select {myOwners.length < 1 ? "an" : "another"} owner
-                                            </option>
-                                            {
-                                                allOwners.map(owner =>  {
-                                                    return <option
-                                                        key={owner.id}
-                                                        value={owner.id}>{owner.name}</option>
-                                                })
-                                            }
+                                        onChange={() => {}} >
+                                        <option value="">
+                                            Select {myOwners.length < 1 ? "an" : "another"} owner
+                                        </option>
+                                        {
+                                            allOwners.map(o => <option key={o.id} value={o.id}>{o.name}</option>)
+                                        }
                                     </select>
                                     : null
                             }
-
 
                             {
                                 detailsOpen && "treatments" in currentAnimal

--- a/src/components/animals/Animal.js
+++ b/src/components/animals/Animal.js
@@ -68,12 +68,6 @@ export const Animal = ({ animal, syncAnimals,
         }
     }, [animalId])
 
-    const assignNewOwner = (chgEvt) => {
-            AnimalOwnerRepository
-                .assignOwner(currentAnimal.id, parseInt(chgEvt.target.value))
-                .then(() => syncAnimals() )
-    }
-
     return (
         <>
             <li className={classes}>
@@ -136,7 +130,11 @@ export const Animal = ({ animal, syncAnimals,
                                         name="owner"
                                         className="form-control small"
                                         onChange={
-                                            assignNewOwner
+                                            (chgEvt) => {
+                                                AnimalOwnerRepository
+                                                    .assignOwner(currentAnimal.id, parseInt(chgEvt.target.value))
+                                                    .then(() => syncAnimals() )
+                                            }
                                         } >
                                             <option value="0">
                                                 Select {myOwners.length < 1 ? "an" : "another"} owner


### PR DESCRIPTION
WHICH ISSUE DOES THIS ADDRESS? Addresses issue #12 – Assign owner to animal

Changes Made:

1. Amended owners display ff ln 122 to map myOwners
2. Added useEffect at line 34 to listen for changes to animal and resolveResource
3. Amended "Owner" selector to limit visibility only to employees, update AnimalOwnerRepository.assignOwner, and re-render DOM to display all assigned owners.

No added files

Recommendations for Testing

Fetch file “KLL-ticket12_assignOwnerToAnimal” and check it out. Log in as employee and non-employee users and confirm only employees are able to view selector, and when a new owner is assigned, DOM is re-rendered to show all owners.

NOTE:  There is still an anomaly with animal "Blue."  Blue shows no owners, but there are two owners assigned in API.  When an additional owner is selected, all three owners are displayed and the selector is removed form the DOM.  This requires a new ticket.